### PR TITLE
add debug_printf() and optimize the debug_set_log

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -5,14 +5,26 @@
 
 #include "debug.h"
 
-FILE * LOG_FILE = NULL;
+FILE * LOG_FILE = stderr;
 
 void debug_set_log(FILE * log_file) {
-    LOG_FILE = log_file;
+    if(log_file != NULL)
+        LOG_FILE = log_file;
+    else
+        LOG_FILE = stderr;
 }
 
 FILE * debug_get_log() {
-    return LOG_FILE != NULL ? LOG_FILE : stderr;
+    return LOG_FILE;
+}
+
+void debug_printf(const char * format, ...)
+{
+    va_list args;
+
+    va_start(args, format);
+    vfprintf(LOG_FILE, format, args);
+    va_end(args);
 }
 
 void debug_fprintf(FILE * log_file, const char * format, ...) {

--- a/debug.h
+++ b/debug.h
@@ -17,6 +17,7 @@ void debug_set_log(FILE * log_file);
 FILE * debug_get_log();
 
 void debug_fprintf(FILE * log_file, const char * format, ...);
+void debug_printf(const char * format, ...);
 
 #ifdef NDEBUG
 #define debug(M, ...)
@@ -28,8 +29,8 @@ void debug_fprintf(FILE * log_file, const char * format, ...);
 
 #define debug_errno() (errno == 0 ? "None" : strerror(errno))
 
-#define log_error(M, ...) debug_fprintf(debug_get_log(), "[ERROR] (%s:%d: errno: %s) " M "\n", __FILE__, __LINE__, debug_errno(), ##__VA_ARGS__)
-#define log_warning(M, ...) debug_fprintf(debug_get_log(), "[WARNING] (%s:%d: errno: %s) " M "\n", __FILE__, __LINE__, debug_errno(), ##__VA_ARGS__)
-#define log_info(M, ...) debug_fprintf(debug_get_log(), "[INFO] (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+#define log_error(M, ...) debug_printf("[ERROR] (%s:%d: errno: %s) " M "\n", __FILE__, __LINE__, debug_errno(), ##__VA_ARGS__)
+#define log_warning(M, ...) debug_printf("[WARNING] (%s:%d: errno: %s) " M "\n", __FILE__, __LINE__, debug_errno(), ##__VA_ARGS__)
+#define log_info(M, ...) debug_printf("[INFO] (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__)
 
 #endif


### PR DESCRIPTION
the debug_printf function will be used to avoid calling debug_set_log every time
and remove the check FILE_LOG == NULL and make the check only 
happens when setting the log file
